### PR TITLE
Add citations for biological context figures

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,27 +102,49 @@
                     <div class="slideshow">
                         <div class="slide fullfade">
                             <img src="img/actin_comparison_figure_a_diagram.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                            </p>
                         </div>
                         <div class="slide fullfade">
                             <img src="img/bibeau2023twist_fig2A.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                                <br /><br />
+                                JP Bibeau, NG Pandit, S Gray, N Shatery Nejad, CV Sindelar, W Cao, EM De La Cruz. <strong>Twist response of actin filaments</strong> (Figure 2A). <em>Proceedings of the National Academy of Sciences</em>, 120(4):e2208536120, 2023. DOI: <a target="_blank" href="https://doi.org/10.1073/pnas.2208536120">10.1073/pnas.2208536120</a>
+                            </p>
                         </div>
                         <div class="slide fullfade">
                             <img src="img/reynolds2022bending_fig3A.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                                <br /><br />
+                                MJ Reynolds, C Hachicho, AG Carl, R Gong, GM Alushin. <strong>Bending forces and nucleotide state jointly regulate F-actin structure</strong> (Figure 3A). <em>Nature</em>, 611:380-386, 2022. DOI: <a target="_blank" href="https://doi.org/10.1038/s41586-022-05366-w">10.1038/s41586-022-05366-w</a>
+                            </p>
                         </div>
                         <div class="slide fullfade">
                             <img src="img/jasnin2013threedimensional_figS4G.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                                <br /><br />
+                                M Jasnin, S Asano, E Gouin, R Hegerl, JM Plitzko, E Villa, P Cossart, W Baumeister. <strong>Three-dimensional architecture of actin filaments in Listeria monocytogenes comet tails</strong> (Figure S4G). <em>Proceedings of the National Academy of Sciences</em>, 110(51):20521-20526, 2013. DOI: <a target="_blank" href="https://doi.org/10.1073/pnas.1320155110">10.1073/pnas.1320155110</a>
+                            </p>
                         </div>
                         <div class="slide fullfade">
                             <img src="img/jasnin2022elasticity_fig1C.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                                <br /><br />
+                                M Jasnin, J Hervy, S Balor, A Bouissou, A Proag, R Voituriez, J Schneider, T Mangeat, I Maridonneau-Parini, W Baumeister, S Dmitrieff, R Poincloux. <strong>Elasticity of podosome actin networks produces nanonewton protrusive forces</strong> (Figure 1C). <em>Nature Communications</em>, 13:3842, 2022. DOI: <a target="_blank" href="https://doi.org/10.1038/s41467-022-30652-6">10.1038/s41467-022-30652-6</a>
+                            </p>
                         </div>
                         <div class="slide fullfade">
                             <img src="img/serwas2022mechanistic_fig2B.png" />
-                            <p>Caption here for image.</p>
+                            <p>
+                                TODO: Caption here for image.
+                                <br /><br />
+                                D Serwas, M Akamatsu, A Moayed, K Vegesna, R Vasan, JM Hill, J Schöneberg, KM Davies, P Rangamani, DG Drubin. <strong>Mechanistic insights into actin force generation during vesicle formation from cryo-electron tomography</strong> (Figure 2B). <em>Developmental Cell</em>, 57(9):1132-1145, 2022. DOI: <a target="_blank" href="https://doi.org/10.1016/j.devcel.2022.04.012">10.1016/j.devcel.2022.04.012</a>
+                            </p>
                         </div>
                         <a class="prev" onclick="prevSlide()">&#10094;</a>
                         <a class="next" onclick="nextSlide()">&#10095;</a>

--- a/index.html
+++ b/index.html
@@ -443,8 +443,8 @@
         </section>
 
         <section id="footer">
-            <p id="schoneberg_2013_readdy">[1] Schöneberg J and Noé F. ReaDDy-a software for particle-based reaction-diffusion dynamics in crowded cellular environments. <em>PloS ONE</em>, <strong>8</strong>(9):e74261, 2013.</p>
-            <p id="nedelec_2007_collective">[2] Nedelec F and Foethke D. Collective Langevin dynamics of flexible cytoskeletal fibers. <em>New Journal of Physics</em>, <strong>9</strong>(11):427, 2007.</p>
+            <p id="schoneberg_2013_readdy">[1] J Schöneberg J and F Noé. <strong>ReaDDy - A software for particle-based reaction-diffusion dynamics in crowded cellular environments</strong>. <em>PLoS ONE</em>, 8(9):e74261, 2013. DOI: <a target="_blank" href="https://doi.org/10.1371/journal.pone.0074261">10.1371/journal.pone.0074261</a></p>
+            <p id="nedelec_2007_collective">[2] F Nedelec and D Foethke. <strong>Collective Langevin dynamics of flexible cytoskeletal fibers</strong>. <em>New Journal of Physics</em>, 9(11):427, 2007. DOI: <a target="_blank" href="https://doi.org/10.1088/1367-2630/9/11/427">10.1088/1367-2630/9/11/427</a></p>
         </section>
     </main>
 </body>

--- a/style/style.css
+++ b/style/style.css
@@ -66,6 +66,11 @@ td img {
     width: 80px;
 }
 
+a {
+    color: #d3d3d3;
+    font-weight: bold;
+}
+
 .inputs {
     padding: 0 0 5px 0;
     display: block;


### PR DESCRIPTION
_Estimated size: xsmall_

Added citations for all the biological context figures. Left TODOs for the captions, we can handle those in a separate PR.

Also updated the default link styling to be white/bold, which should not override any of the existing link styling handled by classes.